### PR TITLE
[Frontend] Feature/31 confirmation and error messages

### DIFF
--- a/src/app/auth/auth.js
+++ b/src/app/auth/auth.js
@@ -5,7 +5,7 @@ import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { createSession } from "./session.js";
 
-import { signUpFormSchema, loginFormSchema } from "./errordefinition.js";
+import { signUpFormSchema, loginFormSchema } from "../utils/errordefinition.js";
 
 // Hardcoded user details
 const hardcodedUser = {

--- a/src/app/profile/components/failBar.jsx
+++ b/src/app/profile/components/failBar.jsx
@@ -1,0 +1,39 @@
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+export default function FailBar({ open, handleClose }) {
+    return (
+        <Snackbar
+        open={open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+         sx={{ 
+                width: { xs: '90%', sm: '75%', md: '600px' },  // Responsive width
+                mx: 'auto',  // Center it horizontally
+                mt: 2,  // Add margin to place below the form
+                px: { xs: 1, sm: 2 },  // Add padding for better spacing
+                mb: { xs: '6%', sm: '6%',md:'10%' }  // Add margin to place above the form
+            }}
+        message="Failed to update your profile. Please try again.">
+            
+            <Alert
+            
+             severity="error"
+            variant="filled"
+         sx={{ 
+                    width: '100%', 
+                    fontSize: { xs: '14px', sm: '16px' },  // Adjust font size for small screens
+                    borderRadius: '8px',  // Rounded corners
+                    boxShadow: '0px 2px 10px rgba(0,0,0,0.2)',  // Custom shadow
+                    textAlign: 'center',
+                    padding: { xs: '8px', sm: '12px' }  // Responsive padding
+                }}
+          >
+        <strong>Error</strong><br/> Please try again!
+  </Alert>
+        </Snackbar>
+        
+        
+    );
+}

--- a/src/app/profile/components/successBar.jsx
+++ b/src/app/profile/components/successBar.jsx
@@ -1,0 +1,39 @@
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+export default function SuccessBar({ open, handleClose }) {
+    return (
+        <Snackbar
+        open={open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+       sx={{ 
+                width: { xs: '90%', sm: '75%', md: '600px' },  // Responsive width
+                mx: 'auto',  // Center it horizontally
+                mt: 2,  // Add margin to place below the form
+                px: { xs: 1, sm: 2 },  // Add padding for better spacing
+                mb: { xs: '6%', sm: '6%',md:'10%' }  // Add margin to place above the form
+            }}
+        message="Your profile has been updated successfully!">
+            
+            <Alert
+            
+             severity="success"
+            variant="filled"
+           sx={{ 
+                    width: '100%', 
+                    fontSize: { xs: '14px', sm: '16px' },  // Adjust font size for small screens
+                    borderRadius: '8px',  // Rounded corners
+                    boxShadow: '0px 2px 10px rgba(0,0,0,0.2)',  // Custom shadow
+                    textAlign: 'center',
+                    padding: { xs: '8px', sm: '12px' }  // Responsive padding
+                }}
+          >
+        <strong> Saved Changes </strong><br/> Your profile has been updated successfully!
+  </Alert>
+        </Snackbar>
+        
+        
+    );
+}

--- a/src/app/profile/components/successBar.jsx
+++ b/src/app/profile/components/successBar.jsx
@@ -8,12 +8,13 @@ export default function SuccessBar({ open, handleClose }) {
         autoHideDuration={6000}
         onClose={handleClose}
          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-       sx={{ 
-                width: { xs: '90%', sm: '75%', md: '600px' },  // Responsive width
+         sx={{ 
+                width: '100%', 
+                height: '10%',  // Adjust height
+                maxWidth: '600px',  // Adjust the width of the snackbar
                 mx: 'auto',  // Center it horizontally
-                mt: 2,  // Add margin to place below the form
-                px: { xs: 1, sm: 2 },  // Add padding for better spacing
-                mb: { xs: '6%', sm: '6%',md:'10%' }  // Add margin to place above the form
+                mt: 2  ,
+                 marginBottom:"6%"
             }}
         message="Your profile has been updated successfully!">
             

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -1,0 +1,171 @@
+"use client";
+import React, { useState } from "react";
+import {
+  Container,
+  TextField,
+  Button,
+  Typography,
+  Box,
+  IconButton,
+  useMediaQuery,
+  useTheme,
+  Divider,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+
+import { ProfileFormSchema } from "../utils/errordefinition";
+
+
+export default function ProfilePage() {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+
+  const [isEditable, setIsEditable] = useState(false);
+  const [formData, setFormData] = useState({
+    fullName: "Mg Mg",
+    email: "mgmg@domain.com",
+    phoneNumber: "09123456789",
+    address: "11th Street, Between 72&73 Streets",
+  });
+    const [errors, setErrors] = useState({});
+
+  const handleEdit = () => {
+    setIsEditable(true);
+    
+  };
+
+  const handleSave = () => {
+    try{
+        ProfileFormSchema.parse({
+        fullName: formData.fullName,
+        phoneNumber: formData.phoneNumber,
+        address: formData.address,
+      });
+    setIsEditable(false);
+    alert("Profile updated successfully!");
+    setErrors({});
+    }
+    catch(error){
+        setErrors(error.formErrors.fieldErrors);
+      
+  };
+}
+
+  const handleChange = (e) => {
+  
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{}}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          width: "100%",
+          textAlign: "center",
+          py: 2, // Padding for better spacing
+        }}
+      >
+        <Box sx={{ flexGrow: 1, display: "flex", justifyContent: "center" }}>
+          <Typography variant="h4" fontWeight="bold">
+            Profile
+          </Typography>
+        </Box>
+        <IconButton aria-label="close">
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <Divider sx={{ width: "100%", borderColor: "rgba(0,0,0,0.2)" }} />
+      <Box
+        maxWidth="sm"
+        sx={{
+          mt: 10,
+          mx: "auto",
+          p: 2,
+        }}
+      >
+        <TextField
+          name="fullName"
+          label="Full Name"
+          value={formData.fullName}
+          onChange={handleChange}
+          fullWidth
+          disabled={!isEditable}
+          sx={{ my: 2 }}
+          error={errors.fullName}
+          helperText={errors.fullName}
+        />
+        <TextField
+          name="email"
+          label="Email"
+          value={formData.email}
+          onChange={handleChange}
+          fullWidth
+          disabled
+          sx={{ my: 2 }}
+        />
+        <TextField
+          name="phoneNumber"
+          label="Phone Number"
+          value={formData.phoneNumber}
+          onChange={handleChange}
+          fullWidth
+          disabled={!isEditable}
+          sx={{ my: 2 }}
+          error={errors.phoneNumber}
+          helperText={errors.phoneNumber}
+        />
+        <TextField
+          name="address"
+          label="Address"
+          value={formData.address}
+          onChange={handleChange}
+          fullWidth
+          disabled={!isEditable}
+          sx={{ my: 2 }}
+            error={errors.address}
+            helperText={errors.address}
+        />
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 2,
+            mt: 2,
+          }}
+        >
+          <Button
+            variant="contained"
+            sx={{
+              bgcolor: "#E0E0E0",
+              color: "#000000",
+              maxwidth: "200px",
+            }}
+            disabled={isEditable}
+            onClick={handleEdit}
+          >
+            Edit Profile
+          </Button>
+
+          <Button
+            variant="contained"
+            fullWidth
+            disabled={!isEditable}
+            sx={{ flex: 1 }}
+            onClick={handleSave}
+          >
+            Save Changes
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+  }
+

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -14,6 +14,9 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 
 import { ProfileFormSchema } from "../utils/errordefinition";
+import  SuccessBar  from "./components/successBar";
+import FailBar from "./components/failBar";
+import { set } from "zod";
 
 
 export default function ProfilePage() {
@@ -22,6 +25,8 @@ export default function ProfilePage() {
 
 
   const [isEditable, setIsEditable] = useState(false);
+  const [openSuccessBar, setOpenSuccessBar] = useState(false);
+  const [closeSuccessBar, setCloseSuccessBar] = useState(false);
   const [formData, setFormData] = useState({
     fullName: "Mg Mg",
     email: "mgmg@domain.com",
@@ -35,15 +40,43 @@ export default function ProfilePage() {
     
   };
 
-  const handleSave = () => {
+
+const SaveChanges = async (validatedData) => {
+  try {
+    const response = await fetch("/api/profile/updateProfile", {
+      method: "PUT",
+      body: JSON.stringify(validatedData),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (response.ok) {
+      // Show success message
+    setOpenSuccessBar(true);
+    } else {
+      // Show error message
+      setCloseSuccessBar(true);
+    }
+  } catch (error) {
+    console.log("Error: ", error);
+    setErrors(error.formErrors?.fieldErrors || {});
+  }
+};
+
+
+  const handleSave =async () => {
     try{
-        ProfileFormSchema.parse({
+       const validatedData= ProfileFormSchema.parse({
         fullName: formData.fullName,
         phoneNumber: formData.phoneNumber,
         address: formData.address,
       });
     setIsEditable(false);
-    alert("Profile updated successfully!");
+  
+    await SaveChanges({validatedData});
+   
+     
+
     setErrors({});
     }
     catch(error){
@@ -129,8 +162,8 @@ export default function ProfilePage() {
           fullWidth
           disabled={!isEditable}
           sx={{ my: 2 }}
-            error={errors.address}
-            helperText={errors.address}
+          error={errors.address}
+          helperText={errors.address}
         />
         <Box
           sx={{
@@ -164,6 +197,18 @@ export default function ProfilePage() {
             Save Changes
           </Button>
         </Box>
+        <FailBar
+          open={closeSuccessBar}
+          handleClose={() => {
+            setCloseSuccessBar(false);
+          }}
+        />
+        <SuccessBar
+          open={openSuccessBar}
+          handleClose={() => {
+            setOpenSuccessBar(false);
+          }}
+        />
       </Box>
     </Container>
   );

--- a/src/app/utils/errordefinition.js
+++ b/src/app/utils/errordefinition.js
@@ -13,3 +13,9 @@ export const loginFormSchema = z.object({
   email: z.string().email({ message: "Please enter a valid email." }),
   password: z.string().min(1, { message: "Password field must not be empty." }),
 });
+
+export const ProfileFormSchema = z.object({
+  fullName: z.string().min(1, { message: "Full name must not be empty." }),
+  phoneNumber: z.string().min(6, { message: "Invalid phone number." }),
+  address: z.string().min(1, { message: "Address must not be empty." }),
+})


### PR DESCRIPTION
 I implemented 
- change errordefinition to` utils` folder
- client side validation 
- implement success and fail UI components from server response 

_Result for ClientSide validations_
![image](https://github.com/user-attachments/assets/30979394-994f-46f8-8bd1-531095147932)


_Output Result for UI components from server-side response_
![image](https://github.com/user-attachments/assets/f5813ee8-8f5b-485a-9b7d-0335669dca67)
